### PR TITLE
HouseNumber

### DIFF
--- a/src/Business/Address.php
+++ b/src/Business/Address.php
@@ -28,7 +28,9 @@ class Address
         $writer->setIndentString("    ");
         $writer->startElementNs($ns, 'Adresa', null);
         $writer->writeElementNs($ns, 'Ulica', null, $this->street);
-        $writer->writeElementNs($ns, 'KucniBroj', null, $this->houseNumber);
+        if($this->houseNumber != null) {
+            $writer->writeElementNs($ns, 'KucniBroj', null, $this->houseNumber);
+        }
         if($this->extrahouseNumber != null) {
             $writer->writeElementNs($ns, 'KucniBrojDodatak', null, $this->extrahouseNumber);
         }


### PR DESCRIPTION
When Business have only ExtrahouseNumber like 'Ilica bb', HouseNumber is null and cannot be send to CIS because it doesn't comply to Shema. HouseNumber must be sent only if not null.