### PR TITLE
Fix for certificate meta data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }],
     "require": {
         "php": ">=7.3.0",
-        "nesbot/carbon": "^2.*"
+        "nesbot/carbon": "2.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }],
     "require": {
         "php": ">=7.3.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^2.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Fiskalizacija.php
+++ b/src/Fiskalizacija.php
@@ -96,7 +96,7 @@ class Fiskalizacija
 
         $X509Issuer = $this->publicCertificateData['issuer'];
         $X509IssuerName = sprintf('CN=%s, O=%s, C=%s', $X509Issuer['CN'], $X509Issuer['O'], $X509Issuer['C']);
-        $X509IssuerSerial = $this->publicCertificateData['serialNumber'];
+        $X509IssuerSerial = base_convert($this->publicCertificateData['serialNumber'], 16, 10);
 
         $publicCertificatePureString = str_replace('-----BEGIN CERTIFICATE-----', '', $this->certificate['cert']);
         $publicCertificatePureString = str_replace('-----END CERTIFICATE-----', '', $publicCertificatePureString);

--- a/src/Fiskalizacija.php
+++ b/src/Fiskalizacija.php
@@ -19,6 +19,8 @@ class Fiskalizacija
     public $certificate;
     private $security;
     private $url = "https://cis.porezna-uprava.hr:8449/FiskalizacijaService";
+    private $privateKeyResource;
+    private $publicCertificateData;
 
     public function __construct($path, $pass, $security = 'SSL', $demo = false)
     {
@@ -93,7 +95,7 @@ class Fiskalizacija
         $SignedInfoNode = $XMLRequestDOMDoc->getElementsByTagName('SignedInfo')->item(0);
 
         $X509Issuer = $this->publicCertificateData['issuer'];
-        $X509IssuerName = sprintf('OU=%s,O=%s,C=%s', $X509Issuer['OU'], $X509Issuer['O'], $X509Issuer['C']);
+        $X509IssuerName = sprintf('CN=%s, O=%s, C=%s', $X509Issuer['CN'], $X509Issuer['O'], $X509Issuer['C']);
         $X509IssuerSerial = $this->publicCertificateData['serialNumber'];
 
         $publicCertificatePureString = str_replace('-----BEGIN CERTIFICATE-----', '', $this->certificate['cert']);


### PR DESCRIPTION
FINA cert no longer uses OU, instead has CN. This causes a PHP warning.