### PR TITLE
Fix for higher numbered certs

### DIFF
--- a/src/Fiskalizacija.php
+++ b/src/Fiskalizacija.php
@@ -94,7 +94,7 @@ class Fiskalizacija
 
         $X509Issuer = $this->publicCertificateData['issuer'];
         $X509IssuerName = sprintf('OU=%s,O=%s,C=%s', $X509Issuer['OU'], $X509Issuer['O'], $X509Issuer['C']);
-        $X509IssuerSerial = $this->publicCertificateData['serialNumber'];
+        $X509IssuerSerial = base_convert($this->publicCertificateData['serialNumber'], 16, 10);
 
         $publicCertificatePureString = str_replace('-----BEGIN CERTIFICATE-----', '', $this->certificate['cert']);
         $publicCertificatePureString = str_replace('-----END CERTIFICATE-----', '', $publicCertificatePureString);


### PR DESCRIPTION
This fixes issues with newer certs that have a higher number. This method will work for older machines as well as newer ones. Fixes #14