### PR TITLE
Dodana kompatibilnost s Laravel verzijom 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }],
     "require": {
         "php": ">=7.3.0",
-        "nesbot/carbon": "2.*",
+        "nesbot/carbon": "2.*|3.*",
         "endroid/qr-code": "^5.0",
         "goetas-webservices/xsd2php-runtime": "^0.2.16"
     },


### PR DESCRIPTION
Zadnja verzija Laravel 12 zahtjeva nestbot/carbon verziju 3. Ovaj paket zahtjeva 2, pa ga se ne može instalirati s novijom verzijom Laravela. Ovaj PR riješava tu kompatibilnost tako da dozvoljava korištenje paketa nestbot/carbon 2 ili 3.