### PR TITLE
Use RSA-SHA256 for XML signature

### DIFF
--- a/src/Fiskalizacija.php
+++ b/src/Fiskalizacija.php
@@ -73,7 +73,7 @@ class Fiskalizacija
         $XMLRequestDOMDoc->loadXML($XMLRequest);
 
         $canonical   = $XMLRequestDOMDoc->C14N();
-        $DigestValue = base64_encode(hash('sha1', $canonical, true));
+        $DigestValue = base64_encode(hash('sha256', $canonical, true));
 
         $rootElem = $XMLRequestDOMDoc->documentElement;
 
@@ -87,7 +87,7 @@ class Fiskalizacija
         $CanonicalizationMethodNode->setAttribute('Algorithm', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
         $SignatureMethodNode = $SignedInfoNode->appendChild(new DOMElement('SignatureMethod'));
-        $SignatureMethodNode->setAttribute('Algorithm', 'http://www.w3.org/2000/09/xmldsig#rsa-sha1');
+        $SignatureMethodNode->setAttribute('Algorithm', 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256');
 
         $ReferenceNode = $SignedInfoNode->appendChild(new DOMElement('Reference'));
         $ReferenceNode->setAttribute('URI', sprintf('#%s', $XMLRequestDOMDoc->documentElement->getAttribute('Id')));
@@ -101,7 +101,7 @@ class Fiskalizacija
         $Transform2Node->setAttribute('Algorithm', 'http://www.w3.org/2001/10/xml-exc-c14n#');
 
         $DigestMethodNode = $ReferenceNode->appendChild(new DOMElement('DigestMethod'));
-        $DigestMethodNode->setAttribute('Algorithm', 'http://www.w3.org/2000/09/xmldsig#sha1');
+        $DigestMethodNode->setAttribute('Algorithm', 'http://www.w3.org/2001/04/xmlenc#sha256');
 
         $ReferenceNode->appendChild(new DOMElement('DigestValue', $DigestValue));
 
@@ -116,7 +116,7 @@ class Fiskalizacija
 
         $this->signedInfoSignature = null;
 
-        if (!openssl_sign($SignedInfoNode->C14N(true), $this->signedInfoSignature, $this->privateKeyResource, OPENSSL_ALGO_SHA1)) {
+        if (!openssl_sign($SignedInfoNode->C14N(true), $this->signedInfoSignature, $this->privateKeyResource, OPENSSL_ALGO_SHA256)) {
             throw new Exception('Unable to sign the request');
         }
 


### PR DESCRIPTION
Izmjene od 01.07.2026 u DEMO/testnoj okolini F1
- Od 01.05.2026. do zaključno 31.12.2026. se u produkciji omogućuje potpisivanje XML poruka
zahtjeva uz metodu RSA-SHA1 dodatno i s metodom potpisivanja RSA-SHA256
- Od 01.07.2026. se u testnoj okolini odbijaju poruke zahtjeva potpisane metodom RSA-SHA1
- Od 01.07.2026. se u testnoj okolini odbija uspostava konekcije enkripcijskim protokolom TLS v1.1
- Od 01.01.2027. se u produkcijskoj okolini odbijaju poruke zahtjeva potpisane metodom RSA-SHA1
- Od 01.01.2027. se u produkcijskoj okolini odbija uspostava konekcije enkripcijskim protokolom TLS v 1.1

Dokumentacija na poveznici:
[https://porezna.gov.hr/fiskalizacija..._v2.7 (16.06.2026.).pdf](https://porezna-uprava.gov.hr/UserDocsImages/Fiskalizacija/Tehni%C4%8Dke%20specifikacije/Fiskalizacija%20-%20Tehnicka%20specifikacija%20za%20korisnike_v2.7%20(16.06.2026.).pdf)